### PR TITLE
 Fixed bug: favorites list cut-out.

### DIFF
--- a/app/src/main/java/com/gacode/relaunchx/ReLaunch.java
+++ b/app/src/main/java/com/gacode/relaunchx/ReLaunch.java
@@ -2797,7 +2797,7 @@ public class ReLaunch extends Activity {
 			app.addStartDir(fullName);
 			break;
 		case CNTXT_MENU_ADD:
-			if (type.equals("file"))
+			if (type == FsItemType.File)
 				app.addToList("favorites", dname, fname, false);
 			else
 				app.addToList("favorites", fullName, app.DIR_TAG, false);

--- a/app/src/main/res/layout-hdpi/results_layout.xml
+++ b/app/src/main/res/layout-hdpi/results_layout.xml
@@ -123,13 +123,12 @@
         <GridView
             android:id="@+id/results_list"
             android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
             android:duplicateParentState="true"
             android:numColumns="3"
             android:smoothScrollbar="false"
-            android:stretchMode="columnWidth" >
-        </GridView>
+            android:stretchMode="columnWidth"></GridView>
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout-mdpi/results_layout.xml
+++ b/app/src/main/res/layout-mdpi/results_layout.xml
@@ -120,13 +120,12 @@
         <GridView
             android:id="@+id/results_list"
             android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
             android:duplicateParentState="true"
             android:numColumns="3"
             android:smoothScrollbar="false"
-            android:stretchMode="columnWidth" >
-        </GridView>
+            android:stretchMode="columnWidth"></GridView>
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
When Favorites (for books, not apps) contains few elements, last one
was cut out. For example at 8 elements, last element was barely visible
(tested on Boyue T63).