### PR TITLE
Supplemented white list of compatible devices.

### DIFF
--- a/app/src/main/res/values/limitations.xml
+++ b/app/src/main/res/values/limitations.xml
@@ -6,6 +6,7 @@
         <item>EBX-5047</item>
         <item>Max</item>
         <item>Max2</item>
+        <item>C67ML_Carta2</item>
     </string-array>
     <string-array name="allowed_manufacturers">
         <item>BarnesAndNobble</item>
@@ -18,11 +19,13 @@
         <item>PRS-T1</item>
         <item>Max</item>
         <item>Max2</item>
+        <item>C67ML_Carta2</item>
     </string-array>
     <string-array name="allowed_products">
         <item>NOOK</item>
         <item>Max</item>
         <item>Max2</item>
+        <item>C67ML_Carta2</item>
     </string-array>
 
 </resources>


### PR DESCRIPTION
Added C67ML_Carta2 (Boyue T63 JDRead).